### PR TITLE
fix: remove old jQuery to restore carousel

### DIFF
--- a/xml
+++ b/xml
@@ -1512,7 +1512,6 @@ margin:0;
   <style>.hidehome{display:none}</style>
 </b:if>
 <b:include data='blog' name='google-analytics'/>
-<script async='async' src='https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js' type='text/javascript'/>
 <script async='async' type='text/javascript'>
 //<![CDATA[
 //CSS Ready


### PR DESCRIPTION
## Summary
- drop obsolete jQuery 1.11 include that overwrote Owl Carousel
- ensure only modern jQuery 3.7.1 loads before carousel assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e1c30efc8832ab3d226b4713a5efe